### PR TITLE
Adding ability to use Live Server for Edge

### DIFF
--- a/sites/dance-party/.vscode/launch.json
+++ b/sites/dance-party/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "edge",
+            "request": "launch",
+            "name": "Launch Edge against localhost",
+            "url": "http://localhost:4200",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
This is configured to allow Edge to be used as a Live Server. Other browsers can be set up here as well. This is just personal preference to me and I don't want to remove it every time. 